### PR TITLE
Update links to NT Maker Community Slack

### DIFF
--- a/_sections/04-contact.md
+++ b/_sections/04-contact.md
@@ -2,7 +2,7 @@
 title: Contact
 include: sections/contact.html
 github_username: darwinmakers
-slack_channel: NT Maker Community
+slack_channel: ntmakers
 slack_join: https://slack.darwinmakers.org/
 ---
 Most of out community conversation takes place on Slack and we welcome new members. We are currently not active on other social media channels but please let us know if you have a particular platform you would like to see us on.

--- a/_sections/04-contact.md
+++ b/_sections/04-contact.md
@@ -2,7 +2,7 @@
 title: Contact
 include: sections/contact.html
 github_username: darwinmakers
-slack_channel: darwinwebstandards
-slack_join: https://slack.darwinwebstandards.org/
+slack_channel: NT Maker Community
+slack_join: https://slack.darwinmakers.org/
 ---
 Most of out community conversation takes place on Slack and we welcome new members. We are currently not active on other social media channels but please let us know if you have a particular platform you would like to see us on.


### PR DESCRIPTION
I've updated the footer link for slack to use the new NT Maker Community title and https://slack.darwinmakers.org URL.