### PR TITLE
add events.ics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 _site
 .sass-cache
 .jekyll-cache

--- a/events.ics
+++ b/events.ics
@@ -11,7 +11,7 @@ ORGANIZER;CN="Darwin Makers":MAILTO:contact@darwinmakers.org
 LOCATION:{{event.location.title}}
 URL:http://darwinmakers.org{{site.baseurl}}{{event.url}}
 SUMMARY:{{ event.title }}
-DESCRIPTION:{{event.excerpt | newline_to_br | replace: '<br />', '\n' | strip_html | strip |  truncatewords: 30 }}
+DESCRIPTION:{{event.excerpt | newline_to_br | replace: '<br />', '\n' | strip_html | strip |  truncate: 60 }}
 CLASS:PUBLIC
 DTSTART:{{ event.date | date: "%Y%m%d" }}T170000Z
 DTEND:{{ event.date | date: "%Y%m%d" }}T190000Z

--- a/events.ics
+++ b/events.ics
@@ -1,0 +1,20 @@
+---
+layout: none
+---
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:http://darwinmakers.org
+METHOD:PUBLISH
+{% for event in site.events limit:10 %}BEGIN:VEVENT
+UID:{{event.title | truncate: 40, "" | trim | url_encode }}{{ event.date | date: "%Y%m%d" }}@darwinmakers.org
+ORGANIZER;CN="Darwin Makers":MAILTO:contact@darwinmakers.org
+LOCATION:{{event.location.title}}
+URL:http://darwinmakers.org{{site.baseurl}}{{event.url}}
+SUMMARY:{{ event.title }}
+DESCRIPTION:{{event.excerpt | newline_to_br | replace: '<br />', '\n' | strip_html | strip |  truncatewords: 30 }}
+CLASS:PUBLIC
+DTSTART:{{ event.date | date: "%Y%m%d" }}T170000Z
+DTEND:{{ event.date | date: "%Y%m%d" }}T190000Z
+DTSTAMP:{{ event.date | date: "%Y%m%d" }}T170000Z
+END:VEVENT
+{% endfor %}END:VCALENDAR


### PR DESCRIPTION
The description is concatanated at 60 characters to avoid exceeding the maximum line length of 75 characters. https://icalendar.org/iCalendar-RFC-5545/3-1-content-lines.html

Ideally, it could be folded to allow longer descriptions but I can't find a way to split the string by length so a custom filter may be required to overcome this limitation.